### PR TITLE
Correct spelling of Cocoapods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SwiftRestModel is a small helper class for communicating with RESTful APIs using
 
 ## Integration
 
-You can use [Cocoapods](http://cocoapods.org) to install `SwiftRestModel` by adding it to your `Podfile`:
+You can use [CocoaPods](http://cocoapods.org) to install `SwiftRestModel` by adding it to your `Podfile`:
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
@@ -34,7 +34,7 @@ App Transport Security is blocking a cleartext HTTP (http://) resource load sinc
 ```
 
 ## Example Project
-You'll need to install [Cocoapods](http://cocoapods.org) first.
+You'll need to install [CocoaPods](http://cocoapods.org) first.
 
 Grab the source code, and then install dependencies.
 ```bash


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
