### PR TITLE
Handle errors for responses outside successful status codes

### DIFF
--- a/Source/SwiftRestModel.swift
+++ b/Source/SwiftRestModel.swift
@@ -139,7 +139,9 @@ public class SwiftRestModel: NSObject
                         json["status"] = JSON(responseStatus)
                     }
 
-                    error!(response: json)
+                    if error != nil {
+                        error!(response: json)
+                    }
                 }
         }
     }

--- a/Source/SwiftRestModel.swift
+++ b/Source/SwiftRestModel.swift
@@ -123,19 +123,23 @@ public class SwiftRestModel: NSObject
         }
         
         Alamofire.request(requestMethod, url, parameters: parameters, headers: headers, encoding: encoding)
+            .validate()
             .responseJSON { response in
-                if response.result.isSuccess {
+                switch response.result {
+                case .Success:
                     let json = JSON(data: response.data!)
                     self.data = json
                     self.parse()
                     if success != nil {
                         success!(response: json)
                     }
-                } else {
-                    let json: JSON = ["error": (response.result.error?.userInfo["NSLocalizedDescription"])!]
-                    if error != nil {
-                        error!(response: json)
+                case .Failure(let responseError):
+                    var json = JSON(["error": responseError.localizedDescription])
+                    if let responseStatus = response.response?.statusCode {
+                        json["status"] = JSON(responseStatus)
                     }
+
+                    error!(response: json)
                 }
         }
     }

--- a/Tests/SwiftRestModelTests.swift
+++ b/Tests/SwiftRestModelTests.swift
@@ -106,7 +106,7 @@ class SwiftRestModelTests: XCTestCase {
         
         self.waitForExpectationsWithTimeout(5.0, handler: nil)
     }
-    
+
     func testErrorHandler() {
         let expectation = self.expectationWithDescription("error-handler")
         
@@ -114,12 +114,28 @@ class SwiftRestModelTests: XCTestCase {
         model.fetch(
             error: {
                 response in
-                XCTAssertNotNil(response, "response is empty")
-                XCTAssertNotNil(response["error"], "response error is empty")
+                XCTAssertNotNil(response, "response is not empty")
+                XCTAssertNotNil(response["error"], "response error is not empty")
                 expectation.fulfill()
         })
         
         self.waitForExpectationsWithTimeout(5.0, handler: nil)
     }
-    
+
+    func testErrorWithResponse() {
+        let expectation = self.expectationWithDescription("error-response-handler")
+        model.rootUrl = "http://jsonplaceholder.typicode.com/fakemodel"
+
+        model.fetch(
+            error: {
+                response in
+                XCTAssertNotNil(response, "response is not empty")
+                XCTAssertNotNil(response["error"], "response is not empty")
+                XCTAssertEqual(response["status"], 404, "status code is 404")
+                expectation.fulfill()
+        })
+
+        self.waitForExpectationsWithTimeout(5.0, handler: nil)
+    }
+
 }


### PR DESCRIPTION
The request method now includes a call to `.validate()`, faulting to the failure block for any response outside the 200..299 range. In the request handler, we now switch on the response type, and pass through a JSON error that includes a response status code when available.

Previously, the failure handler would throw a bad access exception at [this line](https://github.com/Rentlio/SwiftRestModel/blob/master/Source/SwiftRestModel.swift#L135) by forcefully unwrapping the `userInfo["NSLocalizedDescription"]`. This uses the Alamofire `Result` enum's `Failure` value to safely access the objects localized description.